### PR TITLE
Updates grunt-hash for Grunt 0.4

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,12 +1,13 @@
 module.exports = function(grunt) {
 
+  // Load local tasks.
+  grunt.loadTasks('tasks');
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+
   // Project configuration.
   grunt.initConfig({
     test: {
       files: ['test/**/*.js']
-    },
-    lint: {
-      files: ['grunt.js', 'tasks/**/*.js', 'test/**/*.js']
     },
     hash: {
       src: 'examples/*.js',
@@ -18,6 +19,7 @@ module.exports = function(grunt) {
       tasks: 'default'
     },
     jshint: {
+      files: ['grunt.js', 'tasks/**/*.js', 'test/**/*.js'],
       options: {
         curly: true,
         eqeqeq: true,
@@ -37,10 +39,7 @@ module.exports = function(grunt) {
     }
   });
 
-  // Load local tasks.
-  grunt.loadTasks('tasks');
-
   // Default task.
-  grunt.registerTask('default', 'lint hash');
+  grunt.registerTask('default', ['jshint', 'hash']);
 
 };

--- a/examples/assets.json
+++ b/examples/assets.json
@@ -1,1 +1,1 @@
-{"test1":"test1.b93fd451.js","test2":"test2.2870d71a.js"}
+{"test1.js":"test1.b93fd451.js","test2.js":"test2.2870d71a.js"}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt": "~0.3.17"
+    "grunt": "0.4.x",
+    "grunt-contrib-jshint": "0.1.x"
   },
   "keywords": [
     "gruntplugin"

--- a/tasks/hash.js
+++ b/tasks/hash.js
@@ -26,7 +26,7 @@ module.exports = function(grunt) {
     options.dest = options.dest || '';
     var map = {};
 
-    grunt.file.expandFiles(options.src).forEach(function(file) {
+    grunt.file.expand(options.src).forEach(function(file) {
 
       var source = fs.readFileSync(file, 'utf8'); 
       var hash = getHash(source);


### PR DESCRIPTION
- Sets updated dependencies
- Moves grunt.js to Gruntfile.js
- Updates lint to new jshint syntax
- Removes deprecated file.expandFiles in main task

I would suggest to keep it as a branch until 0.4.0 is released.
