### PR TITLE
Proper use of encoding for hashing international characters.

### DIFF
--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,11 +1,11 @@
 
 var crypto = require('crypto');
 
-module.exports = function(source) {
+module.exports = function(source, encoding) {
 
   var md5sum = crypto.createHash('md5');
 
-  md5sum.update(source);
+  md5sum.update(source, encoding );
 
   var d = md5sum.digest('hex');
   var hash = d.substr(0, 8);

--- a/tasks/hash.js
+++ b/tasks/hash.js
@@ -32,8 +32,8 @@ module.exports = function(grunt) {
 
     grunt.file.expand(options.src).forEach(function(file) {
 
-      var source = fs.readFileSync(file, 'utf8'); 
-      var hash = getHash(source);
+      var source = fs.readFileSync(file, 'utf8');
+      var hash = getHash(source, 'utf8');
       var ext = path.extname(file);
       var basename = path.basename(file, ext);
 


### PR DESCRIPTION
The [documentation for hash.update()](http://nodejs.org/api/crypto.html#crypto_hash_update_data_input_encoding) states that if no encoding is given, the argument is expected to be a Buffer.

Like many other "hash tasks" for Grunt, grunt-hash [provides the contents of the file as a string](https://github.com/jgallen23/grunt-hash/blob/master/lib/hash.js#L8) to `hash.update` without any encoding as a second argument, which is incorrect.

The result of this is an incorrect hash for files with international characters in them when no encoding is given to `hash.update`.

Setting the proper encoding when calling `hash.update` fixes this.

PS. I could not find any proper tests in place.
