### PR TITLE
Refactor to support standard Multi-task configuration (Fix #6)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,10 +7,37 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
     hash: {
-      src: 'examples/*.js',
-      //mapping: 'examples/assets.json',
-      mapping: 'examples/assets.php',
-      dest: 'examples/dist/'
+      php: {
+        options: {
+          mapping: 'examples/assets.php'
+        },
+        src: 'examples/*.js',
+        dest: 'examples/dist/php/'
+      },
+      json: {
+        options: {
+          mapping: 'examples/assets.json'
+        },
+        src: 'examples/*.js',
+        dest: 'examples/dist/json/'
+      },
+      single: {
+        options: {
+          mapping: 'examples/single.json'
+        },
+        src: 'examples/test1.js',
+        dest: 'examples/dist/single/'
+      },
+      no_dest: {
+        options: {
+          mapping: 'examples/no_dest.json'
+        },
+        src: 'examples/test1.js'
+      },
+      no_map: {
+        src: 'examples/*.js',
+        dest: 'examples/dist/no_map/'
+      }
     },
     watch: {
       files: '<config:lint.files>',

--- a/README.md
+++ b/README.md
@@ -27,13 +27,17 @@ grunt.loadNpmTasks('grunt-hash');
 ```javascript
 grunt.initConfig({
 	hash: {
+		options {
+			mapping: 'examples/assets.json', //mapping file so your server can serve the right files
+		},
 		src: 'examples/*.js',  //all your js that needs a hash appended to it
-		mapping: 'examples/assets.json', //mapping file so your server can serve the right files
 		dest: 'examples/dist/' //where the new files will be created
 	}
 });
 grunt.loadNpmTasks('grunt-hash');
 ```
+
+Configuration follow the multi-task standard configuration format: http://gruntjs.com/configuring-tasks
 
 
 ## Contributing

--- a/examples/assets.json
+++ b/examples/assets.json
@@ -1,1 +1,0 @@
-{"test1.js":"test1.b93fd451.js","test2.js":"test2.2870d71a.js"}

--- a/examples/assets.php
+++ b/examples/assets.php
@@ -1,1 +1,0 @@
-<?php return json_decode('{"test1.js":"test1.b93fd451.js","test2.js":"test2.2870d71a.js"}'); ?>

--- a/examples/dist/test1.b93fd451.js
+++ b/examples/dist/test1.b93fd451.js
@@ -1,3 +1,0 @@
-var a = function() {
-  return true;
-}

--- a/examples/dist/test2.2870d71a.js
+++ b/examples/dist/test2.2870d71a.js
@@ -1,3 +1,0 @@
-var b = function() {
-  return false;
-}


### PR DESCRIPTION
There is the multi-task support.

I also refactored some of the code to use the built-in Grunt file system helpers. It's way less verbose than the `fs` functions and help to keep the code focused on the business logic rather than the implementation details.

I added some configs to the `Gruntfile` to have a more complete "test" scheme as there's no unit test yet.

It will probably broke some precedent configurations as Multi-task use the `options` hash rather than plain keys; so it would require a minor bump of version before publishing.

Hope this helps!
