### PR TITLE
Clarified documentation a tiny bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,14 @@ grunt.initConfig({
 		options {
 			mapping: 'examples/assets.json', //mapping file so your server can serve the right files
 		},
-		src: 'examples/*.js',  //all your js that needs a hash appended to it
-		dest: 'examples/dist/' //where the new files will be created
+        js: {
+            src: 'examples/*.js',  //all your js that needs a hash appended to it
+            dest: 'examples/dist/js/' //where the new files will be created
+        },
+        css: {
+            src: 'examples/*.css',  //all your css that needs a hash appended to it
+            dest: 'examples/dist/css/' //where the new files will be created
+        }
 	}
 });
 grunt.loadNpmTasks('grunt-hash');


### PR DESCRIPTION
I noticed the example in the documentation was formatted in a way that would not let the `hash.js` task access the src/dest properties properly. Tried to fix it by poking around at the code, but realized I was just configuring it badly. Had already forked, so thought I might just perform a pull request for the relevant documentation changes.
