### PR TITLE
Minor fix and option from https://github.com/guardian/frontend

### DIFF
--- a/lib/hash.js
+++ b/lib/hash.js
@@ -7,7 +7,5 @@ module.exports = function(source, encoding) {
 
   md5sum.update(source, encoding );
 
-  var d = md5sum.digest('hex');
-  var hash = d.substr(0, 8);
-  return hash;
+  return md5sum.digest('hex');
 };

--- a/tasks/hash.js
+++ b/tasks/hash.js
@@ -25,7 +25,8 @@ module.exports = function(grunt) {
     var options = this.options({
       srcBasePath: "",
       destBasePath: "",
-      flatten: false
+      flatten: false,
+      hashLength: 8
     });
     var map = {};
     var mappingExt = path.extname(options.mapping);
@@ -38,7 +39,7 @@ module.exports = function(grunt) {
     this.files.forEach(function(file) {
       file.src.forEach(function(src) {
         var source = grunt.file.read(src);
-        var hash = getHash(source, 'utf8');
+        var hash = getHash(source, 'utf8').substr(0, options.hashLength);
         var dirname = path.dirname(src);
         var rootDir = path.relative(options.srcBasePath, dirname);
         var ext = path.extname(src);


### PR DESCRIPTION
We're using `grunt-hash` to build asset bundles for mobile on [theguardian.com](http://www.theguardian.com/uk?view=mobile). We had a minor glitch with writing binary files. Also made the hash length configurable to match our existing style.
