### PR TITLE
Only append hash extension if there is a hash

### DIFF
--- a/tasks/hash.js
+++ b/tasks/hash.js
@@ -48,7 +48,7 @@ module.exports = function(grunt) {
         // Default destination to the same directory
         var dest = file.dest || path.dirname(src);
 
-        var newFile = basename + '.' + hash + ext;
+        var newFile = basename + (hash ? '.' + hash : '') + ext;
         var outputPath = path.join(dest, newFile);
 
         // Determine if the key should be flatten or not. Also normalize the output path


### PR DESCRIPTION
When setting `hashSize` to 0, the filename created was of the format

```
style..css
```

(double full-stops)

This PR only appends the hash if it exists, creating more sensible filenames, e.g.

```
style.css
```
