### PR TITLE
Create correct hashes on binary files

### DIFF
--- a/tasks/hash.js
+++ b/tasks/hash.js
@@ -40,7 +40,7 @@ module.exports = function(grunt) {
           return;
         }
 
-        var source = grunt.file.read(src);
+        var source = grunt.file.read(src, {encoding: null});
         var hash = options.hashFunction(source, 'utf8').substr(0, options.hashLength);
         var destPath = path.dirname(file.dest);
         var ext = path.extname(src);


### PR DESCRIPTION
This stops `grunt.file.read` from trying to do conversions on the file contents.  For me, this was necessary to generate correct md5 hashes of font assets (wof, eot, ttf).
